### PR TITLE
add compatibility with new table format (2023)

### DIFF
--- a/calendar-structures.js
+++ b/calendar-structures.js
@@ -4,20 +4,21 @@ class CreneauBrut {
     constructor(champs) {
         this.uv = champs[0];
         this.type = champs[1];
-        this.jour = champs[2];
-        this.heure_debut = champs[3];
-        this.heure_fin = champs[4];
-        this.frequence = champs[5];
-        if(champs[6] == "Distanciel" && champs.length > 7) {
-            this.salle = champs[7];
-            this.mode_ens = champs[6];
-        } else if (champs[6] == "Distanciel") {
-            this.mode_ens = champs[6];
-        } else if (champs.length > 7) {
-            this.salle = champs[7];
-            this.mode_ens = champs[6];
+        this.semaine = champs[2];
+        this.jour = champs[3];
+        this.heure_debut = champs[4];
+        this.heure_fin = champs[5];
+        this.frequence = champs[6];
+        if(champs[7] == "Distanciel" && champs.length > 8) {
+            this.salle = champs[8];
+            this.mode_ens = champs[7];
+        } else if (champs[7] == "Distanciel") {
+            this.mode_ens = champs[7];
+        } else if (champs.length > 8) {
+            this.salle = champs[8];
+            this.mode_ens = champs[7];
         } else {
-            this.salle = champs[6];
+            this.salle = champs[7];
         }
     }
 

--- a/calendar.js
+++ b/calendar.js
@@ -21,7 +21,6 @@ let date_fin_vacances_2 = $('#date_fin_vacances_2')[0];
 let maintenant = new Date();
 
 /* Date de début des cours */
-date_debut_cours.min = maintenant.toISOString().split('T')[0];
 date_debut_cours.value = maintenant.toISOString().split('T')[0];
 date_debut_cours.addEventListener('change',function(){
     let nlle_date = new Date(date_debut_cours.value);
@@ -131,11 +130,17 @@ function traitement_donnees(valeur) {
         elements.splice(1,1);
         if(typeof(elements[1]) != 'undefined' ) {
             let nouveau_creneau = new CreneauBrut(elements);
-            edt_semi_brut.push(nouveau_creneau);
-            if(nouveau_creneau.convertFreq()==2) {
-                listeForms.push(generateForm(nouveau_creneau,new Date(date_debut_cours.value)));
-            }
 
+            if(nouveau_creneau.convertFreq()==2) {
+                if(nouveau_creneau.semaine === 'A') {
+                    nouveau_creneau.ajouterDate(ajoutJourRelatif(new Date(date_debut_cours.value), nouveau_creneau));
+                }else if(nouveau_creneau.semaine === 'B'){
+                    nouveau_creneau.ajouterDate(ajouterJour(ajoutJourRelatif(new Date(date_debut_cours.value), nouveau_creneau),7));
+                }else{
+                    listeForms.push(generateForm(nouveau_creneau,new Date(date_debut_cours.value)));
+                }
+            }
+            edt_semi_brut.push(nouveau_creneau);
             i++;
         }
         
@@ -143,6 +148,7 @@ function traitement_donnees(valeur) {
     if(edt_semi_brut.length == 0) {
         throw "Erreur de saisie : veuillez rentrer au moins un créneau!";
     }
+
     if(listeForms.length == 0) {
         generate_ics(edt_semi_brut);
     } else {


### PR DESCRIPTION
Depuis l'ajout de la colonne semaine le générateur ne fonctionne plus.
Cette PR rend compatible le programme avec le nouveau format.

Le formulaire n'est plus utilisé et la date de début des UVs est déterminé avec la date de rentrée

![image](https://github.com/lsacienne/calendar-maker/assets/66138267/b9692c74-d907-472e-961e-01b8c328c46d)
